### PR TITLE
Candy machine program parser

### DIFF
--- a/blockbuster/src/error.rs
+++ b/blockbuster/src/error.rs
@@ -11,6 +11,8 @@ pub enum BlockbusterError {
     DeserializationError,
     #[error("Data length is invalid.")]
     InvalidDataLength,
+    #[error("Unknown anchor account discriminator.")]
+    UnknownAccountDiscriminator,
 }
 
 impl From<std::io::Error> for BlockbusterError {

--- a/blockbuster/src/programs/candy_machine/mod.rs
+++ b/blockbuster/src/programs/candy_machine/mod.rs
@@ -1,0 +1,58 @@
+use crate::{
+    error::BlockbusterError,
+    instruction::InstructionBundle,
+    program_handler::{ProgramParser},
+};
+
+use mpl_bubblegum::{get_instruction_type};
+use borsh::de::BorshDeserialize;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::pubkeys;
+
+use plerkle_serialization::account_info_generated::account_info::AccountInfo;
+use mpl_bubblegum::state::metaplex_adapter::MetadataArgs;
+
+pub use mpl_bubblegum::InstructionName;
+pub use mpl_bubblegum::state::leaf_schema::{
+    LeafSchemaEvent,
+    LeafSchema,
+};
+use mpl_token_metadata::state::{Key, Edition, MasterEditionV2, Metadata, ReservationListV1, MasterEditionV1, ReservationListV2, EditionMarker, UseAuthorityRecord, CollectionAuthorityRecord};
+
+use mpl_candy_machine::state::CandyMachines;
+
+pubkeys!(
+    candy_machine_id,
+    "cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ"
+);
+
+pub enum TokenMetadataAccountData {
+    Uninitialized,
+    EditionV1(Edition),
+    MasterEditionV1(MasterEditionV1),
+    MetadataV1(Metadata),
+    MasterEditionV2(MasterEditionV2),
+    EditionMarker(EditionMarker),
+    UseAuthorityRecord(UseAuthorityRecord),
+    CollectionAuthorityRecord(CollectionAuthorityRecord),
+    
+
+    CandyMachine(CandyMachine)
+}
+
+pub struct TokenMetadataAccountState {
+    key: Key,
+    data: TokenMetadataAccountData,
+}
+
+pub struct TokenMetadataParser;
+
+impl ProgramParser for TokenMetadataParser {
+    fn key(&self) -> Pubkey {
+        token_metadata_id()
+    }
+    fn key_match(&self, key: &Pubkey) -> bool {
+        key == &token_metadata_id()
+    }
+
+}

--- a/blockbuster/src/programs/candy_machine/state.rs
+++ b/blockbuster/src/programs/candy_machine/state.rs
@@ -1,0 +1,124 @@
+/// These are copied over from mpl-candy-machine due to current Solana/Anchor version conflict
+/// between that program and mpl-bubblegum, spl-account-compression, and spl-noop.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_sdk::pubkey::Pubkey;
+
+/// Candy machine state and config data.
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Default, Debug, Clone)]
+pub struct CandyMachine {
+    pub authority: Pubkey,
+    pub wallet: Pubkey,
+    pub token_mint: Option<Pubkey>,
+    pub items_redeemed: u64,
+    pub data: CandyMachineData,
+    // there's a borsh vec u32 denoting how many actual lines of data there are currently (eventually equals items available)
+    // There is actually lines and lines of data after this but we explicitly never want them deserialized.
+    // here there is a borsh vec u32 indicating number of bytes in bitmask array.
+    // here there is a number of bytes equal to ceil(max_number_of_lines/8) and it is a bit mask used to figure out when to increment borsh vec u32
+}
+
+/// Collection PDA account
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Default, Debug, Clone)]
+pub struct CollectionPDA {
+    pub mint: Pubkey,
+    pub candy_machine: Pubkey,
+}
+
+/// Collection PDA account
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Default, Debug, Clone)]
+pub struct FreezePDA {
+    // duplicate key in order to find the candy machine without txn crawling
+    pub candy_machine: Pubkey,   // 32
+    pub allow_thaw: bool,        // 1
+    pub frozen_count: u64,       // 8
+    pub mint_start: Option<i64>, // 1 + 8
+    pub freeze_time: i64,        // 8
+    pub freeze_fee: u64,         // 8
+}
+
+/// Candy machine settings data.
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Default, Debug, Clone)]
+pub struct CandyMachineData {
+    pub uuid: String,
+    pub price: u64,
+    /// The symbol for the asset
+    pub symbol: String,
+    /// Royalty basis points that goes to creators in secondary sales (0-10000)
+    pub seller_fee_basis_points: u16,
+    pub max_supply: u64,
+    pub is_mutable: bool,
+    pub retain_authority: bool,
+    pub go_live_date: Option<i64>,
+    pub end_settings: Option<EndSettings>,
+    pub creators: Vec<Creator>,
+    pub hidden_settings: Option<HiddenSettings>,
+    pub whitelist_mint_settings: Option<WhitelistMintSettings>,
+    pub items_available: u64,
+    /// If [`Some`] requires gateway tokens on mint
+    pub gatekeeper: Option<GatekeeperConfig>,
+}
+
+/// Individual config line for storing NFT data pre-mint.
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+pub struct ConfigLine {
+    pub name: String,
+    /// URI pointing to JSON representing the asset
+    pub uri: String,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+pub struct EndSettings {
+    pub end_setting_type: EndSettingType,
+    pub number: u64,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+pub enum EndSettingType {
+    Date,
+    Amount,
+}
+
+// Unfortunate duplication of token metadata so that IDL picks it up.
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+pub struct Creator {
+    pub address: Pubkey,
+    pub verified: bool,
+    // In percentages, NOT basis points ;) Watch out!
+    pub share: u8,
+}
+
+/// Hidden Settings for large mints used with offline data.
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+pub struct HiddenSettings {
+    pub name: String,
+    pub uri: String,
+    pub hash: [u8; 32],
+}
+
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+pub struct WhitelistMintSettings {
+    pub mode: WhitelistMintMode,
+    pub mint: Pubkey,
+    pub presale: bool,
+    pub discount_price: Option<u64>,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+pub enum WhitelistMintMode {
+    // Only captcha uses the bytes, the others just need to have same length
+    // for front end borsh to not crap itself
+    // Holds the validation window
+    BurnEveryTime,
+    NeverBurn,
+}
+
+/// Configurations options for the gatekeeper.
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Default, Debug, Clone)]
+pub struct GatekeeperConfig {
+    /// The network for the gateway token required
+    pub gatekeeper_network: Pubkey,
+    /// Whether or not the token should expire after minting.
+    /// The gatekeeper network must support this if true.
+    pub expire_on_use: bool,
+}

--- a/blockbuster/src/programs/mod.rs
+++ b/blockbuster/src/programs/mod.rs
@@ -1,13 +1,16 @@
 use bubblegum::BubblegumInstruction;
+use candy_machine::CandyMachineAccountData;
 use token_account::TokenProgramAccount;
 
 // pub mod token_metadata;
 pub mod bubblegum;
+pub mod candy_machine;
 pub mod token_account;
 // pub mod gummyroll;
 
 pub enum ProgramParseResult<'a> {
     Bubblegum(&'a BubblegumInstruction),
     TokenProgramAccount(&'a TokenProgramAccount),
+    CandyMachine(&'a CandyMachineAccountData),
     Unknown,
 }


### PR DESCRIPTION
- Add main three candy machine state accounts
- Talked to team and it does not seem like we need any other accounts right now:
  -  TM accounts used in CPIs will be parsed/indexed by TM parser.
  - Other Associated Token Accounts (ATAs) will be parsed/indexed by SPL Token parser.
  - The bitmap stuff used to track which NFTs have been minted doesn't seem to be needed because our indexer probably doesn't need to know which random index was minted.  To me its more like a data structure implementation in the guts of CM than a read API item, but please correct me if I am wrong.