### PR TITLE
Adding `candy_machine_core` parser

### DIFF
--- a/blockbuster/Cargo.toml
+++ b/blockbuster/Cargo.toml
@@ -12,6 +12,7 @@ readme = "../README.md"
 spl-account-compression = { version = "0.1.0", features = ["no-entrypoint"] }
 spl-noop = { version = "0.1.0", features = ["no-entrypoint"] }
 mpl-bubblegum = { path="../../metaplex-program-library/bubblegum/program", version = "0.1.1", features = ["no-entrypoint"] }
+mpl-candy-machine-core = { git = "https://github.com/metaplex-foundation/metaplex-program-library", branch = "febo/candy-machine-core", features = ["no-entrypoint"] }
 mpl-token-metadata = { version = "1.3.6", features = ["no-entrypoint"] }
 plerkle_serialization = { path = "../../digital-asset-validator-plugin/plerkle_serialization", version = "0.2.0" }
 spl-token = { version = "3.0.1", features = ["no-entrypoint"] }

--- a/blockbuster/src/programs/candy_machine/state.rs
+++ b/blockbuster/src/programs/candy_machine/state.rs
@@ -1,6 +1,5 @@
 /// These are copied over from mpl-candy-machine due to current Solana/Anchor version conflict
 /// between that program and mpl-bubblegum, spl-account-compression, and spl-noop.
-
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_sdk::pubkey::Pubkey;
 

--- a/blockbuster/src/programs/candy_machine_core/mod.rs
+++ b/blockbuster/src/programs/candy_machine_core/mod.rs
@@ -1,0 +1,71 @@
+use crate::{
+    error::BlockbusterError,
+    instruction::InstructionBundle,
+    program_handler::{NotUsed, ParseResult, ProgramParser},
+    programs::ProgramParseResult,
+};
+use borsh::BorshDeserialize;
+use mpl_candy_machine_core::CandyMachine;
+use plerkle_serialization::AccountInfo;
+use solana_sdk::{pubkey::Pubkey, pubkeys};
+use std::convert::TryInto;
+
+pubkeys!(
+    candy_machine_core_id,
+    "CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR"
+);
+
+// Anchor account discriminators.
+const CANDY_MACHINE_DISCRIMINATOR: [u8; 8] = [51, 173, 177, 113, 25, 241, 109, 189];
+
+pub enum CandyMachineCoreAccountData {
+    CandyMachineCore(CandyMachine),
+}
+
+impl ParseResult for CandyMachineCoreAccountData {
+    fn result_type(&self) -> ProgramParseResult {
+        ProgramParseResult::CandyMachineCore(self)
+    }
+}
+
+pub struct CandyMachineParser;
+
+impl ProgramParser for CandyMachineParser {
+    fn key(&self) -> Pubkey {
+        candy_machine_core_id()
+    }
+
+    fn key_match(&self, key: &Pubkey) -> bool {
+        key == &candy_machine_core_id()
+    }
+
+    fn handle_account(
+        &self,
+        account_info: &AccountInfo,
+    ) -> Result<Box<dyn ParseResult>, BlockbusterError> {
+        let account_data = if let Some(account_info) = account_info.data() {
+            account_info
+        } else {
+            return Err(BlockbusterError::DeserializationError);
+        };
+
+        let discriminator: [u8; 8] = account_data[0..8].try_into().unwrap();
+
+        let account_type = match discriminator {
+            CANDY_MACHINE_DISCRIMINATOR => {
+                let candy_machine = CandyMachine::try_from_slice(&account_data[8..])?;
+                CandyMachineCoreAccountData::CandyMachineCore(candy_machine)
+            }
+            _ => return Err(BlockbusterError::UnknownAccountDiscriminator),
+        };
+
+        Ok(Box::new(account_type))
+    }
+
+    fn handle_instruction(
+        &self,
+        _bundle: &InstructionBundle,
+    ) -> Result<Box<dyn ParseResult>, BlockbusterError> {
+        Ok(Box::new(NotUsed::new()))
+    }
+}

--- a/blockbuster/src/programs/mod.rs
+++ b/blockbuster/src/programs/mod.rs
@@ -1,12 +1,14 @@
 use bubblegum::BubblegumInstruction;
 use candy_machine::CandyMachineAccountData;
-use token_metadata::TokenMetadataAccountState;
+use candy_machine_core::CandyMachineCoreAccountData;
 use token_account::TokenProgramAccount;
+use token_metadata::TokenMetadataAccountState;
 
 pub mod bubblegum;
 pub mod candy_machine;
-pub mod token_metadata;
+pub mod candy_machine_core;
 pub mod token_account;
+pub mod token_metadata;
 // pub mod gummyroll;
 
 pub enum ProgramParseResult<'a> {
@@ -14,5 +16,6 @@ pub enum ProgramParseResult<'a> {
     TokenMetadata(&'a TokenMetadataAccountState),
     TokenProgramAccount(&'a TokenProgramAccount),
     CandyMachine(&'a CandyMachineAccountData),
+    CandyMachineCore(&'a CandyMachineCoreAccountData),
     Unknown,
 }


### PR DESCRIPTION
- Pulling in from @febo's branch for now since it is not checked into MPL mainline.
- TODO: Still need to add tests.