### PR TITLE
Candy machine basic tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,7 @@ dependencies = [
  "mpl-token-metadata",
  "plerkle_serialization",
  "rand 0.8.5",
+ "solana-geyser-plugin-interface",
  "solana-sdk",
  "spl-account-compression",
  "spl-noop",

--- a/blockbuster/Cargo.toml
+++ b/blockbuster/Cargo.toml
@@ -27,5 +27,6 @@ solana-sdk = "1.10.38"
 
 [dev-dependencies]
 rand = "0.8.5"
+solana-geyser-plugin-interface = { version = ">=1.10" }
 
 

--- a/blockbuster/src/program_handler.rs
+++ b/blockbuster/src/program_handler.rs
@@ -23,6 +23,12 @@ impl NotUsed {
     }
 }
 
+impl Default for NotUsed {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ParseResult for NotUsed {
     fn result_type(&self) -> ProgramParseResult {
         ProgramParseResult::Unknown

--- a/blockbuster/src/programs/candy_guard/mod.rs
+++ b/blockbuster/src/programs/candy_guard/mod.rs
@@ -23,7 +23,7 @@ const CANDY_GUARD_DISCRIMINATOR: [u8; 8] = [44, 207, 199, 184, 112, 103, 34, 181
 const MINT_COUNTER_DISCRIMINATOR: [u8; 8] = [29, 59, 15, 69, 46, 22, 227, 173];
 
 pub enum CandyGuardAccountData {
-    CandyGuard(CandyGuard, CandyGuardData),
+    CandyGuard(CandyGuard, Box<CandyGuardData>),
     MintCounter(MintCounter),
 }
 
@@ -61,7 +61,7 @@ impl ProgramParser for CandyGuardParser {
                 let candy_guard = CandyGuard::try_from_slice(&account_data[8..])?;
                 let candy_guard_data = CandyGuardData::load(&account_data[DATA_OFFSET..])
                     .map_err(|_| BlockbusterError::CandyGuardDataCustomDeserError)?;
-                CandyGuardAccountData::CandyGuard(candy_guard, candy_guard_data)
+                CandyGuardAccountData::CandyGuard(candy_guard, Box::new(candy_guard_data))
             }
             MINT_COUNTER_DISCRIMINATOR => {
                 let mint_counter = MintCounter::try_from_slice(&account_data[8..])?;

--- a/blockbuster/src/programs/candy_machine/mod.rs
+++ b/blockbuster/src/programs/candy_machine/mod.rs
@@ -25,7 +25,7 @@ pub const COLLECTION_PDA_DISCRIMINATOR: [u8; 8] = [203, 128, 119, 125, 234, 89, 
 pub const FREEZE_PDA_DISCRIMINATOR: [u8; 8] = [154, 58, 148, 24, 101, 200, 243, 127];
 
 pub enum CandyMachineAccountData {
-    CandyMachine(CandyMachine),
+    CandyMachine(Box<CandyMachine>),
     CollectionPDA(CollectionPDA),
     FreezePDA(FreezePDA),
 }
@@ -62,7 +62,7 @@ impl ProgramParser for CandyMachineParser {
         let account_type = match discriminator {
             CANDY_MACHINE_DISCRIMINATOR => {
                 let candy_machine = CandyMachine::try_from_slice(&account_data[8..])?;
-                CandyMachineAccountData::CandyMachine(candy_machine)
+                CandyMachineAccountData::CandyMachine(Box::new(candy_machine))
             }
             COLLECTION_PDA_DISCRIMINATOR => {
                 let collection_pda = CollectionPDA::try_from_slice(&account_data[8..])?;

--- a/blockbuster/src/programs/candy_machine/mod.rs
+++ b/blockbuster/src/programs/candy_machine/mod.rs
@@ -12,7 +12,7 @@ use plerkle_serialization::AccountInfo;
 use solana_sdk::{pubkey::Pubkey, pubkeys};
 use std::convert::TryInto;
 
-mod state;
+pub mod state;
 
 pubkeys!(
     candy_machine_id,
@@ -20,9 +20,9 @@ pubkeys!(
 );
 
 // Anchor account discriminators.
-const CANDY_MACHINE_DISCRIMINATOR: [u8; 8] = [51, 173, 177, 113, 25, 241, 109, 189];
-const COLLECTION_PDA_DISCRIMINATOR: [u8; 8] = [203, 128, 119, 125, 234, 89, 232, 157];
-const FREEZE_PDA_DISCRIMINATOR: [u8; 8] = [154, 58, 148, 24, 101, 200, 243, 127];
+pub const CANDY_MACHINE_DISCRIMINATOR: [u8; 8] = [51, 173, 177, 113, 25, 241, 109, 189];
+pub const COLLECTION_PDA_DISCRIMINATOR: [u8; 8] = [203, 128, 119, 125, 234, 89, 232, 157];
+pub const FREEZE_PDA_DISCRIMINATOR: [u8; 8] = [154, 58, 148, 24, 101, 200, 243, 127];
 
 pub enum CandyMachineAccountData {
     CandyMachine(CandyMachine),

--- a/blockbuster/src/programs/token_account/mod.rs
+++ b/blockbuster/src/programs/token_account/mod.rs
@@ -9,7 +9,7 @@ use solana_sdk::{program_pack::Pack, pubkey::Pubkey, pubkeys};
 use spl_token::state::{Account as TokenAccount, Mint};
 
 pubkeys!(
-    TokenProgramID,
+    token_program_id,
     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 );
 
@@ -34,10 +34,10 @@ impl ParseResult for TokenProgramAccount {
 
 impl ProgramParser for TokenAccountParser {
     fn key(&self) -> Pubkey {
-        TokenProgramID()
+        token_program_id()
     }
     fn key_match(&self, key: &Pubkey) -> bool {
-        key == &TokenProgramID()
+        key == &token_program_id()
     }
 
     fn handle_account(
@@ -52,12 +52,12 @@ impl ProgramParser for TokenAccountParser {
 
         let account_type = match account_data.len() {
             165 => {
-                let token_account = TokenAccount::unpack(&account_data).unwrap();
+                let token_account = TokenAccount::unpack(account_data).unwrap();
 
                 TokenProgramAccount::TokenAccount(token_account)
             }
             82 => {
-                let mint = Mint::unpack(&account_data).unwrap();
+                let mint = Mint::unpack(account_data).unwrap();
 
                 TokenProgramAccount::Mint(mint)
             }

--- a/blockbuster/src/programs/token_metadata/mod.rs
+++ b/blockbuster/src/programs/token_metadata/mod.rs
@@ -36,8 +36,8 @@ pub enum TokenMetadataAccountData {
 }
 
 pub struct TokenMetadataAccountState {
-    key: Key,
-    data: TokenMetadataAccountData,
+    pub key: Key,
+    pub data: TokenMetadataAccountData,
 }
 
 impl ParseResult for TokenMetadataAccountState {

--- a/blockbuster/tests/bubblegum_parser_test.rs
+++ b/blockbuster/tests/bubblegum_parser_test.rs
@@ -102,5 +102,7 @@ fn test_basic_success_parsing() {
         assert!(matched.is_ok());
         assert!(b.leaf_update.is_some());
         assert!(b.tree_update.is_some());
+    } else {
+        panic!("Unexpected ProgramParseResult variant");
     }
 }

--- a/blockbuster/tests/bubblegum_parser_test.rs
+++ b/blockbuster/tests/bubblegum_parser_test.rs
@@ -4,7 +4,7 @@ use crate::helpers::{build_instruction, random_list_of, random_pubkey};
 use anchor_lang::{Event, InstructionData};
 use blockbuster::{
     instruction::{InstructionBundle, IxPair},
-    program_handler::{ParseResult, ProgramParser},
+    program_handler::ProgramParser,
     programs::{bubblegum::BubblegumParser, ProgramParseResult},
 };
 use flatbuffers::FlatBufferBuilder;

--- a/blockbuster/tests/candy_machine_parser_test.rs
+++ b/blockbuster/tests/candy_machine_parser_test.rs
@@ -135,7 +135,7 @@ fn test_basic_success_parsing_candy_machine_account() {
     {
         match candy_machine_account_data {
             CandyMachine(parsed_candy_machine) => {
-                assert_eq!(*parsed_candy_machine, test_candy_machine);
+                assert_eq!(*parsed_candy_machine, Box::new(test_candy_machine));
             }
             _ => panic!("Unexpected CandyMachineAccountData variant"),
         }

--- a/blockbuster/tests/candy_machine_parser_test.rs
+++ b/blockbuster/tests/candy_machine_parser_test.rs
@@ -1,0 +1,145 @@
+extern crate core;
+use crate::helpers::{build_account_update, random_list, random_pubkey};
+use blockbuster::programs::candy_machine::{
+    state::{
+        CandyMachine as CandyMachineAccountType, CandyMachineData as CandyMachineDataAccountType,
+        Creator, EndSettingType, EndSettings, GatekeeperConfig, HiddenSettings, WhitelistMintMode,
+        WhitelistMintSettings,
+    },
+    CandyMachineAccountData::CandyMachine,
+};
+use blockbuster::{
+    program_handler::ProgramParser,
+    programs::{
+        candy_machine::{candy_machine_id, CandyMachineParser, CANDY_MACHINE_DISCRIMINATOR},
+        ProgramParseResult,
+    },
+};
+use borsh::BorshSerialize;
+use flatbuffers::FlatBufferBuilder;
+use solana_geyser_plugin_interface::geyser_plugin_interface::ReplicaAccountInfo;
+
+mod helpers;
+
+#[test]
+fn test_setup() {
+    let subject = CandyMachineParser {};
+    assert_eq!(subject.key(), candy_machine_id());
+    assert!(subject.key_match(&candy_machine_id()));
+}
+
+#[test]
+fn test_basic_success_parsing_candy_machine_account() {
+    // Create CandyMachine test data.
+    let end_settings = EndSettings {
+        end_setting_type: EndSettingType::Amount,
+        number: 5000,
+    };
+
+    let creators = vec![
+        Creator {
+            address: random_pubkey(),
+            verified: true,
+            share: 33,
+        },
+        Creator {
+            address: random_pubkey(),
+            verified: false,
+            share: 33,
+        },
+        Creator {
+            address: random_pubkey(),
+            verified: false,
+            share: 33,
+        },
+        Creator {
+            address: random_pubkey(),
+            verified: true,
+            share: 1,
+        },
+    ];
+
+    let hidden_settings = HiddenSettings {
+        name: String::from("name"),
+        uri: String::from("uri"),
+        hash: random_list(32, u8::MAX).try_into().unwrap(),
+    };
+
+    let whitelist_mint_settings = WhitelistMintSettings {
+        mode: WhitelistMintMode::BurnEveryTime,
+        mint: random_pubkey(),
+        presale: true,
+        discount_price: Some(12345),
+    };
+
+    let gatekeeper_config = GatekeeperConfig {
+        gatekeeper_network: random_pubkey(),
+        expire_on_use: true,
+    };
+
+    let candy_machine_data = CandyMachineDataAccountType {
+        uuid: String::from("uri"),
+        price: 991177,
+        symbol: String::from("ABC"),
+        seller_fee_basis_points: 44,
+        max_supply: 100000,
+        is_mutable: true,
+        retain_authority: false,
+        go_live_date: Some(1663833216),
+        end_settings: Some(end_settings),
+        creators,
+        hidden_settings: Some(hidden_settings),
+        whitelist_mint_settings: Some(whitelist_mint_settings),
+        items_available: 55,
+        gatekeeper: Some(gatekeeper_config),
+    };
+
+    let test_candy_machine = CandyMachineAccountType {
+        authority: random_pubkey(),
+        wallet: random_pubkey(),
+        token_mint: Some(random_pubkey()),
+        items_redeemed: 33,
+        data: candy_machine_data,
+    };
+
+    // Borsh serialize the CandyMachine test data.
+    let mut data = CANDY_MACHINE_DISCRIMINATOR.to_vec();
+    test_candy_machine
+        .serialize(&mut data)
+        .expect("Could not serialize candy machine data");
+
+    // Create a `ReplicaAccountInfo` to store the account update.
+    let replica_account_info = ReplicaAccountInfo {
+        pubkey: &random_pubkey().to_bytes()[..],
+        lamports: 1,
+        owner: &random_pubkey().to_bytes()[..],
+        executable: false,
+        rent_epoch: 1000,
+        data: &data,
+        write_version: 1,
+    };
+
+    // Flatbuffer serialize the `ReplicaAccountInfo` into
+    let mut fbb = FlatBufferBuilder::new();
+    let account_info = build_account_update(&mut fbb, &replica_account_info, 0, false)
+        .expect("Could not build account update");
+
+    // Use `CandyMachineParser` to parse the account update.
+    let subject = CandyMachineParser {};
+    let result = subject.handle_account(&account_info);
+    assert!(result.is_ok());
+
+    // Check `ProgramParseResult` and make sure the data is parsed and matches the test data.
+    if let ProgramParseResult::CandyMachine(candy_machine_account_data) =
+        result.unwrap().result_type()
+    {
+        match candy_machine_account_data {
+            CandyMachine(parsed_candy_machine) => {
+                assert_eq!(*parsed_candy_machine, test_candy_machine);
+            }
+            _ => panic!("Unexpected CandyMachineAccountData variant"),
+        }
+    } else {
+        panic!("Unexpected ProgramParseResult variant");
+    }
+}

--- a/blockbuster/tests/candy_machine_parser_test.rs
+++ b/blockbuster/tests/candy_machine_parser_test.rs
@@ -237,6 +237,32 @@ fn test_basic_success_parsing_collection_pda_account() {
 }
 
 #[test]
+fn test_wrong_size_collection_pda_account_fails() {
+    // Borsh serialize the CandyMachine discriminator.
+    let mut data = COLLECTION_PDA_DISCRIMINATOR.to_vec();
+    // Add some random data.
+    data.append(&mut random_list(8, u8::MAX));
+
+    // Flatbuffer serialize the data.
+    let mut fbb = FlatBufferBuilder::new();
+    let account_info =
+        build_random_account_update(&mut fbb, &data).expect("Could not build account update");
+
+    // Use `CandyMachineParser` to parse the account update.
+    let subject = CandyMachineParser {};
+    let result = subject.handle_account(&account_info);
+
+    // Validate expected error.
+    assert!(result.is_err());
+    if let Err(err) = result {
+        match err {
+            BlockbusterError::IOError(_) => (),
+            _ => panic!("Unexpected error: {}", err),
+        }
+    }
+}
+
+#[test]
 fn test_basic_success_parsing_freeze_pda_account() {
     // Create FreezePDA test data.
     let test_freeze_pda = FreezePDAAccountType {
@@ -276,5 +302,31 @@ fn test_basic_success_parsing_freeze_pda_account() {
         }
     } else {
         panic!("Unexpected ProgramParseResult variant");
+    }
+}
+
+#[test]
+fn test_wrong_size_freeze_pda_account_fails() {
+    // Borsh serialize the CandyMachine discriminator.
+    let mut data = FREEZE_PDA_DISCRIMINATOR.to_vec();
+    // Add some random data.
+    data.append(&mut random_list(32, u8::MAX));
+
+    // Flatbuffer serialize the data.
+    let mut fbb = FlatBufferBuilder::new();
+    let account_info =
+        build_random_account_update(&mut fbb, &data).expect("Could not build account update");
+
+    // Use `CandyMachineParser` to parse the account update.
+    let subject = CandyMachineParser {};
+    let result = subject.handle_account(&account_info);
+
+    // Validate expected error.
+    assert!(result.is_err());
+    if let Err(err) = result {
+        match err {
+            BlockbusterError::IOError(_) => (),
+            _ => panic!("Unexpected error: {}", err),
+        }
     }
 }

--- a/blockbuster/tests/helpers.rs
+++ b/blockbuster/tests/helpers.rs
@@ -185,7 +185,13 @@ pub fn build_account_update<'a>(
     // Serialize vector data.
     let pubkey = fbb.create_vector(account.pubkey);
     let owner = fbb.create_vector(account.owner);
-    let data = fbb.create_vector(account.data);
+
+    // Don't serialize a zero-length data slice.
+    let data = if !account.data.is_empty() {
+        Some(fbb.create_vector(account.data))
+    } else {
+        None
+    };
 
     // Serialize everything into Account Info table.
     let account_info = AccountInfo::create(
@@ -196,7 +202,7 @@ pub fn build_account_update<'a>(
             owner: Some(owner),
             executable: account.executable,
             rent_epoch: account.rent_epoch,
-            data: Some(data),
+            data,
             write_version: account.write_version,
             slot,
             is_startup,

--- a/blockbuster/tests/helpers.rs
+++ b/blockbuster/tests/helpers.rs
@@ -208,3 +208,23 @@ pub fn build_account_update<'a>(
     let data = fbb.finished_data();
     root_as_account_info(data)
 }
+
+pub fn build_random_account_update<'a>(
+    fbb: &'a mut FlatBufferBuilder<'a>,
+    data: &[u8]
+) -> Result<AccountInfo<'a>, flatbuffers::InvalidFlatbuffer> {
+    // Create a `ReplicaAccountInfo` to store the account update.
+    // All fields except caller-specified `data` are just random values.
+    let replica_account_info = ReplicaAccountInfo {
+        pubkey: &random_pubkey().to_bytes()[..],
+        lamports: 1,
+        owner: &random_pubkey().to_bytes()[..],
+        executable: false,
+        rent_epoch: 1000,
+        data,
+        write_version: 1,
+    };
+
+    // Flatbuffer serialize the `ReplicaAccountInfo`.
+    build_account_update(fbb, &replica_account_info, 0, false)
+}

--- a/blockbuster/tests/helpers.rs
+++ b/blockbuster/tests/helpers.rs
@@ -1,3 +1,6 @@
+// Workaround since this module is only used for testing.
+#![allow(dead_code)]
+
 extern crate core;
 
 use flatbuffers::{FlatBufferBuilder, WIPOffset};
@@ -169,8 +172,8 @@ pub fn build_instruction<'a>(
     let offset = builder.finish();
     fbb.finish_minimal(offset);
     let data = fbb.finished_data();
-    let c = root_as_compiled_instruction(data);
-    c
+
+    root_as_compiled_instruction(data)
 }
 
 pub fn build_account_update<'a>(
@@ -178,7 +181,7 @@ pub fn build_account_update<'a>(
     account: &ReplicaAccountInfo,
     slot: u64,
     is_startup: bool,
-) -> Result<(AccountInfo<'a>), flatbuffers::InvalidFlatbuffer> {
+) -> Result<AccountInfo<'a>, flatbuffers::InvalidFlatbuffer> {
     // Serialize vector data.
     let pubkey = fbb.create_vector(account.pubkey);
     let owner = fbb.create_vector(account.owner);

--- a/blockbuster/tests/helpers.rs
+++ b/blockbuster/tests/helpers.rs
@@ -211,7 +211,7 @@ pub fn build_account_update<'a>(
 
 pub fn build_random_account_update<'a>(
     fbb: &'a mut FlatBufferBuilder<'a>,
-    data: &[u8]
+    data: &[u8],
 ) -> Result<AccountInfo<'a>, flatbuffers::InvalidFlatbuffer> {
     // Create a `ReplicaAccountInfo` to store the account update.
     // All fields except caller-specified `data` are just random values.


### PR DESCRIPTION
### Tests
```
running 10 tests
test test_setup ... ok
test test_basic_success_parsing_collection_pda_account ... ok
test test_basic_success_parsing_freeze_pda_account ... ok
test test_unknown_discriminator_fails ... ok
test test_unused_instruction_parsing ... ok
test test_basic_success_parsing_candy_machine_account ... ok
test test_zero_length_data_fails ... ok
test test_wrong_size_freeze_pda_account_fails ... ok
test test_wrong_size_candy_machine_account_fails ... ok
test test_wrong_size_collection_pda_account_fails ... ok
```

### Other notes
- Also some cargo clippy fixes
  - Converting some large enum variants to store
data on the heap.
  - Ignore dead code for helpers module.