### PR TITLE
Changes to support collection verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blockbuster"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anchor-lang",
  "async-trait",

--- a/blockbuster/Cargo.toml
+++ b/blockbuster/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blockbuster"
 description = "Metaplex canonical program parsers, for indexing, analytics etc...."
-version = "0.5.8"
+version = "0.5.9"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/blockbuster"
 license = "AGPL-3.0"

--- a/blockbuster/src/programs/bubblegum/mod.rs
+++ b/blockbuster/src/programs/bubblegum/mod.rs
@@ -31,7 +31,7 @@ pub enum Payload {
     CancelRedeem { root: [u8; 32] },
     VerifyCreator { creator: Pubkey },
     UnverifyCreator { creator: Pubkey },
-    SetAndVerifyCollection { collection: Pubkey }
+    SetAndVerifyCollection { collection: Pubkey },
 }
 //TODO add more of the parsing here to minimize program transformer code
 pub struct BubblegumInstruction {
@@ -164,13 +164,19 @@ impl ProgramParser for BubblegumParser {
                         b_inst.payload = Some(Payload::CancelRedeem { root: slice });
                     }
                     InstructionName::VerifyCreator => {
-                       let creator = keys.get(5).ok_or(BlockbusterError::InstructionParsingError)?.0;
+                        let creator = keys
+                            .get(5)
+                            .ok_or(BlockbusterError::InstructionParsingError)?
+                            .0;
                         b_inst.payload = Some(Payload::VerifyCreator {
                             creator: Pubkey::new_from_array(creator),
                         });
                     }
                     InstructionName::UnverifyCreator => {
-                        let creator = keys.get(5).ok_or(BlockbusterError::InstructionParsingError)?.0;
+                        let creator = keys
+                            .get(5)
+                            .ok_or(BlockbusterError::InstructionParsingError)?
+                            .0;
                         b_inst.payload = Some(Payload::UnverifyCreator {
                             creator: Pubkey::new_from_array(creator),
                         });
@@ -181,7 +187,7 @@ impl ProgramParser for BubblegumParser {
                         // Deserializing this to get to the second argument encoded in the slice,
                         // which is the collection address. Is there a (safe) way to get to that
                         // directly?
-                        let _args :MetadataArgs = MetadataArgs::try_from_slice(ix_data)?;
+                        let _args: MetadataArgs = MetadataArgs::try_from_slice(ix_data)?;
                         let collection: Pubkey = Pubkey::try_from_slice(ix_data)?;
                         b_inst.payload = Some(Payload::SetAndVerifyCollection { collection });
                     }

--- a/blockbuster/src/programs/bubblegum/mod.rs
+++ b/blockbuster/src/programs/bubblegum/mod.rs
@@ -31,6 +31,7 @@ pub enum Payload {
     CancelRedeem { root: [u8; 32] },
     VerifyCreator { creator: Pubkey },
     UnverifyCreator { creator: Pubkey },
+    SetAndVerifyCollection { collection: Pubkey }
 }
 //TODO add more of the parsing here to minimize program transformer code
 pub struct BubblegumInstruction {
@@ -163,17 +164,26 @@ impl ProgramParser for BubblegumParser {
                         b_inst.payload = Some(Payload::CancelRedeem { root: slice });
                     }
                     InstructionName::VerifyCreator => {
-                       let creator = keys.get(0).ok_or(BlockbusterError::InstructionParsingError)?.0;
-
+                       let creator = keys.get(5).ok_or(BlockbusterError::InstructionParsingError)?.0;
                         b_inst.payload = Some(Payload::VerifyCreator {
                             creator: Pubkey::new_from_array(creator),
                         });
                     }
                     InstructionName::UnverifyCreator => {
-                        let creator = keys.get(0).ok_or(BlockbusterError::InstructionParsingError)?.0;
+                        let creator = keys.get(5).ok_or(BlockbusterError::InstructionParsingError)?.0;
                         b_inst.payload = Some(Payload::UnverifyCreator {
                             creator: Pubkey::new_from_array(creator),
                         });
+                    }
+                    // We don't extract any additional info w.r.t. verify and unverify
+                    // collection ops for now.
+                    InstructionName::SetAndVerifyCollection => {
+                        // Deserializing this to get to the second argument encoded in the slice,
+                        // which is the collection address. Is there a (safe) way to get to that
+                        // directly?
+                        let _args :MetadataArgs = MetadataArgs::try_from_slice(ix_data)?;
+                        let collection: Pubkey = Pubkey::try_from_slice(ix_data)?;
+                        b_inst.payload = Some(Payload::SetAndVerifyCollection { collection });
                     }
                     _ => {}
                 };

--- a/blockbuster/src/programs/candy_guard/mod.rs
+++ b/blockbuster/src/programs/candy_guard/mod.rs
@@ -64,8 +64,12 @@ impl ProgramParser for CandyGuardParser {
         let account_type = match discriminator {
             CANDY_GUARD_DISCRIMINATOR => {
                 let candy_guard = try_from_slice_unchecked(&account_data[8..])?;
-                let candy_guard_data = CandyGuardData::load(&account_data[DATA_OFFSET..])
-                    .map_err(|_| BlockbusterError::CustomDeserializationError("Candy Guard Data Deserialization Error".to_string()))?;
+                let candy_guard_data =
+                    CandyGuardData::load(&account_data[DATA_OFFSET..]).map_err(|_| {
+                        BlockbusterError::CustomDeserializationError(
+                            "Candy Guard Data Deserialization Error".to_string(),
+                        )
+                    })?;
                 CandyGuardAccountData::CandyGuard(candy_guard, candy_guard_data)
             }
             MINT_COUNTER_DISCRIMINATOR => {

--- a/blockbuster/src/programs/candy_machine_core/mod.rs
+++ b/blockbuster/src/programs/candy_machine_core/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use mpl_candy_machine_core::CandyMachine;
 use plerkle_serialization::AccountInfo;
-use solana_sdk::{pubkey::Pubkey, pubkeys, borsh::try_from_slice_unchecked};
+use solana_sdk::{borsh::try_from_slice_unchecked, pubkey::Pubkey, pubkeys};
 use std::convert::TryInto;
 
 pubkeys!(


### PR DESCRIPTION
This PR adds the minimal required logic to process instructions related to collection verification. Right now, the only setting where that's needed is `SetAndVerifyCollection` because collection information is already available for the individual (un)verify operations.

This commit also updates the key index when parsing the creator account pubkey to 5 (which is the correct 0-based index when analyzing the accounts struct for those particular operations). The previous strange behaviour is no longer present since the validator container has been updated to a more recent version of the plugin repo, and things are working as expected right now.