### PR TITLE
Danenbm/fix update metadata parse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
  "spl-account-compression",
  "spl-concurrent-merkle-tree",
  "spl-noop",
- "spl-token 3.5.0",
+ "spl-token 4.0.0",
  "thiserror",
 ]
 

--- a/blockbuster/Cargo.toml
+++ b/blockbuster/Cargo.toml
@@ -16,7 +16,7 @@ mpl-candy-guard = { version = "2.0.0", features = ["no-entrypoint"] }
 mpl-candy-machine-core = { version = "2.0.0", features = ["no-entrypoint"] }
 mpl-token-metadata = { version = "2.0.0-beta.1", features = ["no-entrypoint", "serde-feature"] }
 plerkle_serialization = { version = "1.6.0" }
-spl-token = { version = ">= 3.5.0, < 5.0", features = ["no-entrypoint"] }
+spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
 async-trait = "0.1.57"
 bs58 = "0.4.0"
 lazy_static = "1.4.0"

--- a/blockbuster/src/programs/bubblegum/mod.rs
+++ b/blockbuster/src/programs/bubblegum/mod.rs
@@ -215,7 +215,7 @@ impl ProgramParser for BubblegumParser {
                         b_inst.payload = Some(build_collection_verification_payload(keys, false)?);
                     }
                     InstructionName::UpdateMetadata => {
-                        let args = UpdateMetadataInstructionArgs::try_from_slice(&outer_ix_data)?;
+                        let args = UpdateMetadataInstructionArgs::try_from_slice(ix_data)?;
                         b_inst.payload = Some(Payload::UpdateMetadata {
                             current_metadata: args.current_metadata,
                             update_args: args.update_args,


### PR DESCRIPTION
### Notes
* Fix parsing UpdateMetadataInstructionArgs
* Use specific SPL token version

### Testing
* Tested as part of: https://github.com/metaplex-foundation/digital-asset-rpc-infrastructure/pull/135