### PR TITLE
Add metadata to creator verification payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
  "spl-account-compression",
  "spl-concurrent-merkle-tree",
  "spl-noop",
- "spl-token 3.5.0",
+ "spl-token 4.0.0",
  "thiserror",
 ]
 

--- a/blockbuster/Cargo.toml
+++ b/blockbuster/Cargo.toml
@@ -16,7 +16,7 @@ mpl-candy-guard = { version = "2.0.0", features = ["no-entrypoint"] }
 mpl-candy-machine-core = { version = "2.0.0", features = ["no-entrypoint"] }
 mpl-token-metadata = { version = "2.0.0-beta.1", features = ["no-entrypoint", "serde-feature"] }
 plerkle_serialization = { version = "1.6.0" }
-spl-token = { version = ">= 3.5.0, < 5.0", features = ["no-entrypoint"] }
+spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
 async-trait = "0.1.57"
 bs58 = "0.4.0"
 lazy_static = "1.4.0"


### PR DESCRIPTION
This will be used to simplify creator verification indexing in DAS API.

Tested as part of https://github.com/metaplex-foundation/digital-asset-rpc-infrastructure/pull/134
