### PR TITLE
Update to use Token Metadata (and latest Bubblegum) Rust clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
  "spl-account-compression",
  "spl-concurrent-merkle-tree",
  "spl-noop",
- "spl-token 4.0.0",
+ "spl-token",
  "thiserror",
 ]
 
@@ -1126,36 +1126,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1174,22 +1150,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core 0.13.4",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core",
  "quote 1.0.33",
  "syn 2.0.38",
 ]
@@ -1228,6 +1193,9 @@ name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "derivation-path"
@@ -1712,6 +1680,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +1862,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1898,6 +1873,7 @@ checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.1",
+ "serde",
 ]
 
 [[package]]
@@ -2155,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-bubblegum"
-version = "1.0.1-beta.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e59d102fe6f8b063a06a226874ea815b269316390ce3bf991b29ea9c54ccc467"
+checksum = "b3cbca5deb859e66a1a21ada94f2eaab3eb5caa4584c0c8ade0efac29a5414b8"
 dependencies = [
  "borsh 0.10.3",
  "kaigan",
@@ -2168,75 +2144,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "mpl-token-auth-rules"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b1ec5ee0570f688cc84ff4624c5c50732f1a2bfc789f6b34af5b563428d971"
-dependencies = [
- "borsh 0.10.3",
- "bytemuck",
- "mpl-token-metadata-context-derive 0.2.1",
- "num-derive 0.3.3",
- "num-traits",
- "rmp-serde",
- "serde",
- "shank",
- "solana-program",
- "solana-zk-token-sdk",
- "thiserror",
-]
-
-[[package]]
 name = "mpl-token-metadata"
-version = "2.0.0-beta.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3545bd5fe73416f6514cd93899612e0e138619e72df8bc7d19906a12688c69e"
+checksum = "2149cabad4ad39d507ab4d210ecac06138f00a9afa17603f4b54af2c13f27499"
 dependencies = [
- "arrayref",
  "borsh 0.10.3",
- "mpl-token-auth-rules",
- "mpl-token-metadata-context-derive 0.3.0",
- "mpl-utils",
  "num-derive 0.3.3",
  "num-traits",
  "serde",
- "serde_with 1.14.0",
- "shank",
+ "serde_with 3.6.0",
  "solana-program",
- "spl-associated-token-account",
- "spl-token 4.0.0",
  "thiserror",
-]
-
-[[package]]
-name = "mpl-token-metadata-context-derive"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12989bc45715b0ee91944855130131479f9c772e198a910c3eb0ea327d5bffc3"
-dependencies = [
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "mpl-token-metadata-context-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a739019e11d93661a64ef5fe108ab17c79b35961e944442ff6efdd460ad01a"
-dependencies = [
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "mpl-utils"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2e4f92aec317d5853c0cc4c03c55f5178511c45bb3dbb441aea63117bf3dc9"
-dependencies = [
- "arrayref",
- "solana-program",
- "spl-token-2022 0.6.1",
 ]
 
 [[package]]
@@ -2384,15 +2303,6 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
@@ -2407,18 +2317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
 dependencies = [
  "num_enum_derive 0.7.0",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2974,28 +2872,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmp"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
-dependencies = [
- "byteorder",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
-]
-
-[[package]]
 name = "rpassword"
 version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3254,16 +3130,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "serde",
- "serde_with_macros 1.5.2",
-]
-
-[[package]]
-name = "serde_with"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
@@ -3273,15 +3139,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with_macros"
-version = "1.5.2"
+name = "serde_with"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
 dependencies = [
- "darling 0.13.4",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 1.0.109",
+ "base64 0.21.4",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.2",
+ "serde",
+ "serde_json",
+ "serde_with_macros 3.6.0",
+ "time",
 ]
 
 [[package]]
@@ -3290,7 +3161,19 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.20.3",
+ "darling",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
+dependencies = [
+ "darling",
  "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 2.0.38",
@@ -3351,40 +3234,6 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
-]
-
-[[package]]
-name = "shank"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63e565b5e95ad88ab38f312e89444c749360641c509ef2de0093b49f55974a5"
-dependencies = [
- "shank_macro",
-]
-
-[[package]]
-name = "shank_macro"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63927d22a1e8b74bda98cc6e151fcdf178b7abb0dc6c4f81e0bbf5ffe2fc4ec8"
-dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "shank_macro_impl",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "shank_macro_impl"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce03403df682f80f4dc1efafa87a4d0cb89b03726d0565e6364bdca5b9a441"
-dependencies = [
- "anyhow",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "serde",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3471,8 +3320,8 @@ dependencies = [
  "solana-address-lookup-table-program",
  "solana-config-program",
  "solana-sdk",
- "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token",
+ "spl-token-2022",
  "spl-token-metadata-interface",
  "thiserror",
  "zstd",
@@ -3935,7 +3784,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022 0.9.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -4111,9 +3960,9 @@ dependencies = [
  "solana-address-lookup-table-program",
  "solana-sdk",
  "spl-associated-token-account",
- "spl-memo 4.0.0",
- "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-memo",
+ "spl-token",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -4263,8 +4112,8 @@ dependencies = [
  "num-derive 0.4.1",
  "num-traits",
  "solana-program",
- "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -4312,15 +4161,6 @@ dependencies = [
  "sha2 0.10.8",
  "syn 2.0.38",
  "thiserror",
-]
-
-[[package]]
-name = "spl-memo"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
-dependencies = [
- "solana-program",
 ]
 
 [[package]]
@@ -4395,21 +4235,6 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.3.3",
- "num-traits",
- "num_enum 0.5.11",
- "solana-program",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08459ba1b8f7c1020b4582c4edf0f5c7511a5e099a7a97570c9698d4f2337060"
@@ -4420,24 +4245,6 @@ dependencies = [
  "num-traits",
  "num_enum 0.6.1",
  "solana-program",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0043b590232c400bad5ee9eb983ced003d15163c4c5d56b090ac6d9a57457b47"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.3.3",
- "num-traits",
- "num_enum 0.5.11",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-memo 3.0.1",
- "spl-token 3.5.0",
  "thiserror",
 ]
 
@@ -4454,9 +4261,9 @@ dependencies = [
  "num_enum 0.7.0",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-memo 4.0.0",
+ "spl-memo",
  "spl-pod",
- "spl-token 4.0.0",
+ "spl-token",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "spl-type-length-value",

--- a/blockbuster/Cargo.toml
+++ b/blockbuster/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 spl-account-compression = { version = "0.2.0", features = ["no-entrypoint"] }
 spl-noop = { version = "0.2.0", features = ["no-entrypoint"] }
 mpl-bubblegum = "1.2.0"
-mpl-token-metadata = { version = "4.0.0", features = ["serde"], git = "https://github.com/metaplex-foundation/mpl-token-metadata.git", rev = "59c3e39b4caaf6aff72cf8849a226244f304be7a" }
+mpl-token-metadata = { version = "4.0.2", features = ["serde"] }
 plerkle_serialization = { version = "1.6.0" }
 spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
 async-trait = "0.1.57"

--- a/blockbuster/Cargo.toml
+++ b/blockbuster/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 spl-account-compression = { version = "0.2.0", features = ["no-entrypoint"] }
 spl-noop = { version = "0.2.0", features = ["no-entrypoint"] }
 mpl-bubblegum = "1.2.0"
-mpl-token-metadata = { version = "4.0.0", features = ["serde"], path = "/home/danenbm/Metaplex-Workspace/mpl-token-metadata/clients/rust" }
+mpl-token-metadata = { version = "4.0.0", features = ["serde"], git = "https://github.com/metaplex-foundation/mpl-token-metadata.git", rev = "59c3e39b4caaf6aff72cf8849a226244f304be7a" }
 plerkle_serialization = { version = "1.6.0" }
 spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
 async-trait = "0.1.57"

--- a/blockbuster/Cargo.toml
+++ b/blockbuster/Cargo.toml
@@ -11,8 +11,8 @@ readme = "../README.md"
 [dependencies]
 spl-account-compression = { version = "0.2.0", features = ["no-entrypoint"] }
 spl-noop = { version = "0.2.0", features = ["no-entrypoint"] }
-mpl-bubblegum = "=1.0.1-beta.4"
-mpl-token-metadata = { version = "2.0.0-beta.1", features = ["no-entrypoint", "serde-feature"] }
+mpl-bubblegum = "1.2.0"
+mpl-token-metadata = { version = "4.0.0", features = ["serde"], path = "/home/danenbm/Metaplex-Workspace/mpl-token-metadata/clients/rust" }
 plerkle_serialization = { version = "1.6.0" }
 spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
 async-trait = "0.1.57"

--- a/blockbuster/src/programs/bubblegum/mod.rs
+++ b/blockbuster/src/programs/bubblegum/mod.rs
@@ -15,7 +15,10 @@ use mpl_bubblegum::{
     },
     types::{BubblegumEventType, MetadataArgs, UpdateArgs},
 };
-pub use mpl_bubblegum::{types::LeafSchema, InstructionName, LeafSchemaEvent, ID};
+pub use mpl_bubblegum::{
+    types::{LeafSchema, UseMethod},
+    InstructionName, LeafSchemaEvent, ID,
+};
 use plerkle_serialization::AccountInfo;
 use solana_sdk::pubkey::Pubkey;
 pub use spl_account_compression::events::{

--- a/blockbuster/src/programs/token_metadata/mod.rs
+++ b/blockbuster/src/programs/token_metadata/mod.rs
@@ -8,7 +8,6 @@ use solana_sdk::{borsh0_10::try_from_slice_unchecked, pubkey::Pubkey, pubkeys};
 
 use plerkle_serialization::AccountInfo;
 
-pub use mpl_bubblegum::{types::LeafSchema, InstructionName, LeafSchemaEvent};
 use mpl_token_metadata::{
     accounts::{
         CollectionAuthorityRecord, DeprecatedMasterEditionV1, Edition, EditionMarker,

--- a/blockbuster/tests/instructions_test.rs
+++ b/blockbuster/tests/instructions_test.rs
@@ -5,8 +5,7 @@ use blockbuster::{
     instruction::{order_instructions, InstructionBundle},
     program_handler::ProgramParser,
     programs::{
-        bubblegum::{BubblegumParser, Payload},
-        token_metadata::LeafSchemaEvent,
+        bubblegum::{BubblegumParser, LeafSchemaEvent, Payload},
         ProgramParseResult,
     },
 };


### PR DESCRIPTION
### Notes
* Left the `serde` feature for `token-metadata` in but I think it could be removed in a follow-on PR.
* Removed `ReservationListV1` and `ReservationListV2` as they aren't parsed in DAS.
* Used `Metadata:safe_deserialize` as it looks like it can handle some edge cases where metadata is the wrong size due to previous changes in Token Metadata.
* As part of this PR I noticed that `MasterEditionV1` and `MasterEditionV2` were switched in the parsing.
  * I think it only works because the first fields are the same and it's using `try_from_slice_unchecked` which doesn't check the whole buffer is used.
  * Looking at how this error propagated into DAS, it resulted in incorrect `key` being used in DAS (see below) which will be fixed after this blockbuster is used.  Note that `attachment_type` is also set to `master_edition_v1`, but that is actually a DAS issue that will be fixed as part of https://github.com/metaplex-foundation/digital-asset-rpc-infrastructure/pull/168.

#### `MasterEditionV2` data indexed by DAS before this change
```
solana=# select * from asset_v1_account_attachments;
                                 id                                 | asset_id |  attachment_type  | initialized |                           data                           | slot_updated 
--------------------------------------------------------------------+----------+-------------------+-------------+----------------------------------------------------------+--------------
 \x0959c32095ea8e4efe3cd3085da48fe76315fb964d75adb35ef77385c4824e8b |          | master_edition_v1 | f           | {"key": "MasterEditionV1", "supply": 0, "max_supply": 0} |           10
 \x2536a1214ca39b157ced46c63e811af89533a0bbb50138dbfd55116caa25dc04 |          | master_edition_v1 | f           | {"key": "MasterEditionV1", "supply": 0, "max_supply": 0} |           16
 \xdf01db9dae8c86894a11e82a5613628009e2adcecf2f1fc370396c9e350a3a84 |          | master_edition_v1 | f           | {"key": "MasterEditionV1", "supply": 0, "max_supply": 0} |            4
 \x038c060efc5b0d94a7e9e3b18a5412d3f8f8ae2f6f2696bf4397db66577d2d77 |          | master_edition_v1 | f           | {"key": "MasterEditionV1", "supply": 0, "max_supply": 0} |           22
 \x1e03d3ca5cc64798343f89b7b2cfabdd1812da638c8e68c7e667b8e452de35e1 |          | master_edition_v1 | f           | {"key": "MasterEditionV1", "supply": 0, "max_supply": 0} |           29
 \x448647109f2d2fde9328d77e24ff6105b751e3ae45b1f31ac277ecb41a66c561 |          | master_edition_v1 | f           | {"key": "MasterEditionV1", "supply": 0, "max_supply": 0} |           35
 \xcf2138727f907817109103c14605015fcde92629aeed463a836cfc8c27a2a15b |          | master_edition_v1 | f           | {"key": "MasterEditionV1", "supply": 0, "max_supply": 0} |           41
 \xa494deba3d99b376a507c729055775ce88cb16a0d9724743e9975858ef86a03f |          | master_edition_v1 | f           | {"key": "MasterEditionV1", "supply": 0, "max_supply": 0} |           47
 \x92abf2c0864539ace0afa35001574fdf68f9fd31f5cd532c349ddd40149cb0bc |          | master_edition_v1 | f           | {"key": "MasterEditionV1", "supply": 0, "max_supply": 0} |           53
 \x0e170152ff4c0c4e29bd56e74ecf0bcea026ca45203ff274ccd00167e9d46305 |          | master_edition_v1 | f           | {"key": "MasterEditionV1", "supply": 0, "max_supply": 0} |           60
```