### PR TITLE
Update mpl-core to version that supports editions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-core"
-version = "0.3.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12ab13d9c75156048c3e6d57717ec3ece59fdcae195124bf1cec82aef5295fa"
+checksum = "de7477a52a59fe4db051c6a83077319288e8bfbd1aaf8511d4f733e3a77b6d24"
 dependencies = [
  "base64 0.22.0",
  "borsh 0.10.3",

--- a/blockbuster/Cargo.toml
+++ b/blockbuster/Cargo.toml
@@ -14,7 +14,7 @@ spl-token-2022 = { version = "1.0", features = ["no-entrypoint"] }
 spl-account-compression = { version = "0.3.0", features = ["no-entrypoint"] }
 spl-noop = { version = "0.2.0", features = ["no-entrypoint"] }
 mpl-bubblegum = "1.2.0"
-mpl-core = { version = "0.3.0", features = ["serde"] }
+mpl-core = { version = "0.4.4", features = ["serde"] }
 mpl-token-metadata = { version = "4.1.1", features = ["serde"] }
 spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
 async-trait = "0.1.57"


### PR DESCRIPTION
This version supports deserializing Print Editions from mpl-core assets.