### PR TITLE
Update to mpl-core client that supports external plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2160,6 +2160,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "modular-bitfield"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
+dependencies = [
+ "modular-bitfield-impl",
+ "static_assertions",
+]
+
+[[package]]
+name = "modular-bitfield-impl"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "mpl-bubblegum"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,15 +2196,18 @@ dependencies = [
 
 [[package]]
 name = "mpl-core"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c11b334e9243b0953095358b7f1e9b17b197a1a3ec9f1ece4be340bcb6b6f2"
+checksum = "69b314fcf76dc22cc42a02a208231c667d0c533ce140d6ba9985df5a2a50b0aa"
 dependencies = [
  "base64 0.22.0",
  "borsh 0.10.3",
+ "modular-bitfield",
  "num-derive 0.3.3",
  "num-traits",
+ "rmp-serde",
  "serde",
+ "serde_json",
  "serde_with 3.7.0",
  "solana-program",
  "thiserror",
@@ -2928,6 +2952,28 @@ dependencies = [
  "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -4348,6 +4394,12 @@ dependencies = [
  "spl-pod",
  "spl-program-error",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/blockbuster/Cargo.toml
+++ b/blockbuster/Cargo.toml
@@ -14,7 +14,7 @@ spl-token-2022 = { version = "1.0", features = ["no-entrypoint"] }
 spl-account-compression = { version = "0.3.0", features = ["no-entrypoint"] }
 spl-noop = { version = "0.2.0", features = ["no-entrypoint"] }
 mpl-bubblegum = "1.2.0"
-mpl-core = { version = "0.5.0", features = ["serde"] }
+mpl-core = { version = "0.7.0", features = ["serde"] }
 mpl-token-metadata = { version = "4.1.1", features = ["serde"] }
 spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
 async-trait = "0.1.57"


### PR DESCRIPTION
This mpl-core change was tested as part of https://github.com/metaplex-foundation/digital-asset-rpc-infrastructure/pull/194
